### PR TITLE
cuAOA HPC Support Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Before proceeding with the installation, ensure the following tools are installe
 - [pip](https://pip.pypa.io/en/stable/installing/): Necessary for Python package installations.
 - [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html): A crucial tool for environment and package management.
 - [uv](https://docs.astral.sh/uv/): Another crucial tool for environment and package management.
-- [Python >= 3.11](https://www.python.org/downloads/): Required for running the Python code. Other versions may work but have not been tested.
+- [Python = 3.11](https://www.python.org/downloads/): Required for running the Python code. Other versions will not work due to incompatibility with maturin.
 
 ### Conda Environment Requirement
 

--- a/cuaoa/internal/Makefile
+++ b/cuaoa/internal/Makefile
@@ -1,13 +1,36 @@
-CUDA_PATH ?= /usr/local/cuda
-NVCC := $(CUDA_PATH)/bin/nvcc
-GPP := g++
+# Detect environment
+CONDA_PREFIX ?= $(shell conda info --json 2>/dev/null | grep -o '"active_prefix": *"[^"]*"' | cut -d'"' -f4)
+ifeq ($(CONDA_PREFIX),)
+    CONDA_PREFIX := /usr
+endif
 
-# Compiler and linker flags
-NVCC_FLAGS := -std=c++20 -arch=sm_86 --expt-relaxed-constexpr -Xcompiler -fPIC,-O3
-GPP_FLAGS := -Iinclude -std=c++20 -march=native -O3 -Wall -fPIC -fopenmp -flto
-LD_FLAGS := -L$(CUDA_PATH)/lib64 -L$(CONDA_PREFIX)/lib -lcudart -lcustatevec -llbfgs -lstdc++ -lgomp
+CUDA_PATH ?= $(shell dirname $(shell dirname $(shell which nvcc)))
+NVCC ?= $(shell which nvcc)
+GPP ?= $(shell which g++)
+# Detect CUDA version
+CUDA_VERSION := $(shell $(NVCC) --version | grep -o -E "release ([0-9]+)\." | cut -d' ' -f2 | cut -d'.' -f1)
 
-# Additional include directories
+# Base NVCC flags
+NVCC_FLAGS := -std=c++17 -Xcompiler="-fPIC -O3" \
+    -gencode arch=compute_70,code=sm_70 \
+    -gencode arch=compute_75,code=sm_75 \
+    -gencode arch=compute_80,code=sm_80 \
+    -gencode arch=compute_86,code=sm_86
+
+# Add CUDA 12+ architectures if supported
+ifeq ($(shell [ $(CUDA_VERSION) -ge 12 ] && echo true),true)
+    NVCC_FLAGS += \
+        -gencode arch=compute_89,code=sm_89 \
+        -gencode arch=compute_90,code=sm_90
+endif
+
+NVCC_FLAGS += --expt-relaxed-constexpr
+
+# Add both lib64 and lib to avoid issues across CUDA 11/12 installs
+LD_FLAGS := -L$(CUDA_PATH)/lib64 -L$(CUDA_PATH)/lib -L$(CONDA_PREFIX)/lib \
+    -lcudart -lcustatevec -llbfgs -lstdc++ -lgomp
+
+# Include directories
 INCLUDE := -I$(CUDA_PATH)/include -I./include -I$(CONDA_PREFIX)/include
 
 # Library and binary target
@@ -26,6 +49,7 @@ RED := \033[0;31m
 GREEN := \033[0;32m
 NC := \033[0m
 
+# Default target
 all: $(TARGET)
 
 $(LIB_TARGET): $(filter-out obj/main.o, $(OBJ))
@@ -48,4 +72,3 @@ clean:
 	@rm -rf obj $(TARGET)
 
 .PHONY: all clean
-

--- a/cuaoa/internal/compile_flags.txt
+++ b/cuaoa/internal/compile_flags.txt
@@ -1,16 +1,15 @@
--std=c++20
--march=sm_86 
---cuda-gpu-arch=sm_86 
--Xcompiler 
--fPIC
--Iinclude 
--O3 
--Wall 
--fPIC 
+-std=c++17
+-Xcompiler=-fPIC
+-O3
+-Wall
 -fopenmp
--I/opt/cuda/include 
--I/home/jflxb/miniforge3/envs/cuaoa/include
+-gencode=arch=compute_70,code=sm_70
+-gencode=arch=compute_75,code=sm_75
+-gencode=arch=compute_80,code=sm_80
+-gencode=arch=compute_86,code=sm_86
+-Iinclude
 -I./include
--lcudart 
--lgomp
--llbfgs
+-I/opt/cuda/include
+# -lcudart
+# -llbfgs
+# -lgomp

--- a/cuaoa/internal/include/polynomial.hpp
+++ b/cuaoa/internal/include/polynomial.hpp
@@ -15,10 +15,10 @@
 
 #ifndef POLYNOMIAL_HPP
 #define POLYNOMIAL_HPP
-
+#include <cstddef>    // for std::size_t
 #include <vector>
 struct Polynomial {
-  std::vector<size_t> keys;
+  std::vector<std::size_t> keys;
   std::vector<double> values;
 };
 
@@ -26,3 +26,4 @@ Polynomial makePolynomialsfromAdjacencyMatrix(const double *flat,
                                               size_t dimension);
 
 #endif
+

--- a/cuaoa/internal/src/polynomial.cpp
+++ b/cuaoa/internal/src/polynomial.cpp
@@ -13,18 +13,20 @@
  * limitations under the License.
  */
 
+#include <vector>
+#include <cstddef>        // for std::size_t
+#include <map>            // or unordered_map if used
+#include <algorithm>      // for std::copy or std::transform if used
 #include "polynomial.hpp"
-#include <map>
-#include <ranges>
 
 Polynomial makePolynomialsfromAdjacencyMatrix(const double *flat,
-                                              size_t dimension) {
-  std::map<size_t, double> polynomial;
+                                              std::size_t dimension) {
+  std::map<std::size_t, double> polynomial;
 
-  for (size_t i = 0; i < dimension; i++) {
+  for (std::size_t i = 0; i < dimension; i++) {
     double contrib = 0.0;
-    for (size_t j = 0; j < dimension; j++) {
-      size_t index = i * dimension + j;
+    for (std::size_t j = 0; j < dimension; j++) {
+      std::size_t index = i * dimension + j;
       double value = flat[index];
 
       bool hasValue = value != 0;
@@ -35,7 +37,7 @@ Polynomial makePolynomialsfromAdjacencyMatrix(const double *flat,
       }
 
       if (hasValue) {
-        size_t key = (1 << i) + (1 << j);
+        std::size_t key = (1 << i) + (1 << j);
         if (polynomial.count(key) > 0) {
           polynomial[key] += value;
         } else {
@@ -54,11 +56,15 @@ Polynomial makePolynomialsfromAdjacencyMatrix(const double *flat,
     }
   }
 
-  auto keys = std::views::keys(polynomial);
-  auto vals = std::views::values(polynomial);
+  std::vector<std::size_t> keys;
+  std::vector<double> vals;
+  for (const auto& [k, v] : polynomial) {
+      keys.push_back(k);
+      vals.push_back(v);
+  }
 
   Polynomial pols;
-  pols.keys = std::vector<size_t>{keys.begin(), keys.end()};
-  pols.values = std::vector<double>{vals.begin(), vals.end()};
+  pols.keys = std::vector<std::size_t>(keys.begin(), keys.end());
+  pols.values = std::vector<double>(vals.begin(), vals.end());
   return pols;
 }

--- a/cuaoa/internal/src/wrapper/device_info.cpp
+++ b/cuaoa/internal/src/wrapper/device_info.cpp
@@ -25,7 +25,7 @@ CudaDeviceInfoResult getCudaDevicesInfo() {
 
   for (int i = 0; i < numDevices; i++) {
     cudaDeviceProp prop;
-    cudaGetDeviceProperties_v2(&prop, i);
+    cudaGetDeviceProperties(&prop, i);
 
     CudaDeviceInfo info;
     info.id = i;

--- a/cuaoa/internal/src/wrapper/polynomial.cpp
+++ b/cuaoa/internal/src/wrapper/polynomial.cpp
@@ -21,11 +21,11 @@
 
 extern "C" {
 
-PolynomialResult makePolynomialsWrapper(const double *flat, size_t dimension) {
+PolynomialResult makePolynomialsWrapper(const double *flat, std::size_t dimension) {
   Polynomial polynomial = makePolynomialsfromAdjacencyMatrix(flat, dimension);
   PolynomialResult result;
   result.keysSize = polynomial.keys.size();
-  result.keys = new size_t[polynomial.keys.size()];
+  result.keys = new std::size_t[polynomial.keys.size()];
   std::copy(polynomial.keys.begin(), polynomial.keys.end(), result.keys);
   result.valuesSize = polynomial.values.size();
   result.values = new double[polynomial.values.size()];

--- a/install.sh
+++ b/install.sh
@@ -37,10 +37,11 @@ echo -e "${LINK}${NC} Installing the ${GREEN}custatevec${NC} and ${GREEN}lbfgs${
 conda install custatevec conda-forge::liblbfgs
 # execute_command "pip install maturin[patchelf]" "Installing the ${GREEN}maturin${NC} build tool with ${GREEN}patchelf${NC}" "$PUZZLE"
 # execute_command "maturin build --release" "Building the project from source... (this might take a while)" "$GEAR "
-execute_command "uv build" "Building the project from source... (this might take a while)" "$GEAR "
-
-WHEEL_FILE=$(find dist -name '*.whl' | sort | tail -n 1)
-
+# execute_command "uv build" "Building the project from source... (this might take a while)" "$GEAR "
+pip install maturin[patchelf]
+execute_command "maturin build --release" "Building the project from source... (this might take a while)" "$GEAR "
+#WHEEL_FILE=$(find dist -name '*.whl' | sort | tail -n 1)
+WHEEL_FILE=$(find target/wheels -name '*.whl' | sort | tail -n 1)
 if [[ ! -z "$WHEEL_FILE" ]]; then
     execute_command "pip install $WHEEL_FILE" "Installing the wheel file with pip..." "$PACKAGE"
     echo -e "${GREEN}${CHECK_MARK}  Installation completed successfully. ${NC}"

--- a/src/pycuaoa/__init__.pyi
+++ b/src/pycuaoa/__init__.pyi
@@ -82,9 +82,9 @@ class CUAOA:
     def get_polynomial(self) -> Polynomial: ...
     def get_num_nodes(self) -> uint64: ...
 
-# BruteFroce
+# BruteForce
 
-class BruteFroce:
+class BruteForce:
     def __init__(
         self,
         adjacency_matrix: NDArray[float64],

--- a/src/pycuaoa/__init__.pyi
+++ b/src/pycuaoa/__init__.pyi
@@ -82,9 +82,9 @@ class CUAOA:
     def get_polynomial(self) -> Polynomial: ...
     def get_num_nodes(self) -> uint64: ...
 
-# BruteForce
+# BruteForce (typo; need to fix all instances later)
 
-class BruteForce:
+class BruteFroce:
     def __init__(
         self,
         adjacency_matrix: NDArray[float64],


### PR DESCRIPTION
The current version of cuAOA is not especially well-suited for use in limited-access HPC environments with multiple GPU types, particularly due to its requirement of CUDA 12 and C++ 20. Therefore, to expand access to users in such environments, the following changes have been made:

- Added compatibility to CUDA 11 (while maintaining CUDA 12 compatibility)
- Altered code to compile properly with C++17 (this is important for compatibility with CUDA 11)
- Added multi-arch compilation
- Install script dynamically adjusts compile_flags.txt 
- Default build is done solely with maturin (though a uv build can still be done by uncommenting the appropriate lines of code)
- Corrected how cuAOA recognizes environment filepaths in Makefile 
- Fixed an incorrect CUDA API call